### PR TITLE
Quick fix broken addon

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon 
-	id="plugin.video.dumpert" 
-	name="Dumpert" 
-	version="1.1.8"
+<addon
+	id="plugin.video.dumpert"
+	name="Dumpert"
+	version="1.1.9"
 	provider-name="Skipmode A1">
   <requires>
     <import addon="xbmc.python"                     version="2.20.0"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+v1.1.9 (2019-09-17)
+- added a quickfix to the legacy dumpert
+- updated logos
+
 v1.1.8 (2018-12-30)
 - added stream videos
 - switched to isengard
@@ -25,9 +29,9 @@ v1.1.3 (2017-03-03):
 - fixed url in addon.xml as per request
 
 v1.1.2 (2016-12-20) (kudos to MartijnKaiser):
-- Use higher resolution thumbnails 
-- Set content to video so skins can set correct view 
-- Set video duration when available 
+- Use higher resolution thumbnails
+- Set content to video so skins can set correct view
+- Set video duration when available
 - using po-files (Skipmode A1)
 - changed addon debugging info to kodi debugging info (Skipmode A1)
 
@@ -65,7 +69,7 @@ v1.0.5 (2015-04-17):
 
 v1.0.4 (2014-06-06):
 - adjustments due to changes in the website: changed get-method
- 
+
 v1.0.3 (2014-04-14):
 - adjustments due to changes in the website. Thanks to TheGroove for helping out with the base64 stuff
 - video quality can be set in the settings now

--- a/resources/lib/dumpert_json.py
+++ b/resources/lib/dumpert_json.py
@@ -42,9 +42,9 @@ class Main(object):
         log("self.video_list_page_url", self.video_list_page_url)
 
         # Determine current page number and base_url
-        # http://www.dumpert.nl/toppers/
-        # http://www.dumpert.nl/
-        # http://www.dumpert.nl/<thema>/
+        # http://legacy.dumpert.nl/toppers/
+        # http://legacy.dumpert.nl/
+        # http://legacy.dumpert.nl/<thema>/
         # find last slash
         pos_of_last_slash = self.video_list_page_url.rfind('/')
         # remove last slash

--- a/resources/lib/dumpert_list.py
+++ b/resources/lib/dumpert_list.py
@@ -42,15 +42,15 @@ class Main(object):
             self.next_page_possible = urllib.parse.parse_qs(urllib.parse.urlparse(sys.argv[2]).query)['next_page_possible'][0]
         except KeyError:
             self.plugin_category = LANGUAGE(30001)
-            self.video_list_page_url = "http://www.dumpert.nl/1/"
+            self.video_list_page_url = "http://legacy.dumpert.nl/1/"
             self.next_page_possible = "True"
 
         log("self.video_list_page_url", self.video_list_page_url)
 
         # Determine current page number and base_url
-        # http://www.dumpert.nl/toppers/
-        # http://www.dumpert.nl/
-        # http://www.dumpert.nl/<thema>/
+        # http://legacy.dumpert.nl/toppers/
+        # http://legacy.dumpert.nl/
+        # http://legacy.dumpert.nl/<thema>/
         # find last slash
         pos_of_last_slash = self.video_list_page_url.rfind('/')
         # remove last slash
@@ -102,7 +102,7 @@ class Main(object):
         log("titles_and_thumbnail_urls", titles_and_thumbnail_urls)
 
         # Find video page urls
-        # <a href="http://www.dumpert.nl/mediabase/2245331/272bd4c3/turnlulz.html" class="dumpthumb" title="Turnlulz">
+        # <a href="http://legacy.dumpert.nl/mediabase/2245331/272bd4c3/turnlulz.html" class="dumpthumb" title="Turnlulz">
         video_page_urls = soup.findAll('a', attrs={'class': re.compile("dumpthumb")})
 
         log("len(video_page_urls)", len(video_page_urls))
@@ -137,7 +137,7 @@ class Main(object):
                 continue
 
             description = '...'
-            #<a href="http://www.dumpert.nl/mediabase/6721593/46f416fa/stukje_snowboarden.html?thema=bikini" class="dumpthumb" title="Stukje snowboarden">
+            #<a href="http://legacy.dumpert.nl/mediabase/6721593/46f416fa/stukje_snowboarden.html?thema=bikini" class="dumpthumb" title="Stukje snowboarden">
             #	<img src="http://media.dumpert.nl/sq_thumbs/6721593_46f416fa.jpg" alt="Stukje snowboarden" title="Stukje snowboarden" width="100" height="100" />
             #	<span class="video"></span>
             #	<div class="details">
@@ -155,9 +155,9 @@ class Main(object):
             # Make title
             try:
                 title = titles_and_thumbnail_urls[titles_and_thumbnail_urls_index]['title']
-            # <a href="http://www.dumpert.nl/mediabase/1958831/21e6267f/pixar_s_up_inspreken.html?thema=animatie" class="dumpthumb" title="Pixar's &quot;Up&quot; inspreken ">
+            # <a href="http://legacy.dumpert.nl/mediabase/1958831/21e6267f/pixar_s_up_inspreken.html?thema=animatie" class="dumpthumb" title="Pixar's &quot;Up&quot; inspreken ">
             except KeyError:
-                # http://www.dumpert.nl/mediabase/6532392/82471b66/dumpert_heeft_talent.html
+                # http://legacy.dumpert.nl/mediabase/6532392/82471b66/dumpert_heeft_talent.html
                 title = str(video_page_url)
                 pos_last_slash = title.rfind('/')
                 pos_last_dot = title.rfind('.')

--- a/resources/lib/dumpert_list_themas.py
+++ b/resources/lib/dumpert_list_themas.py
@@ -43,7 +43,7 @@ class Main(object):
         log("self.video_list_page_url", self.video_list_page_url)
 
         # Determine base_url
-        # http://www.dumpert.nl/
+        # http://legacy.dumpert.nl/
         # find last slash
         pos_of_last_slash = self.video_list_page_url.rfind('/')
         # remove last slash
@@ -98,7 +98,7 @@ class Main(object):
             video_page_url = video_page_url['href']
             # remove '/themas/'
             video_page_url = video_page_url.replace('/themas/', '')
-            # http://www.dumpert.nl/<thema>/
+            # http://legacy.dumpert.nl/<thema>/
             theme_base_url = str(self.base_url) + str(video_page_url)
             current_page = 1
 

--- a/resources/lib/dumpert_main.py
+++ b/resources/lib/dumpert_main.py
@@ -30,7 +30,7 @@ class Main(object):
         #
         # Nieuw
         #
-        parameters = {"action": "list", "plugin_category": LANGUAGE(30001), "url": "http://www.dumpert.nl/1/",
+        parameters = {"action": "list", "plugin_category": LANGUAGE(30001), "url": "http://legacy.dumpert.nl/1/",
                       "next_page_possible": "True"}
         url = self.plugin_url + '?' + urllib.parse.urlencode(parameters)
         list_item = xbmcgui.ListItem(LANGUAGE(30001), iconImage="DefaultFolder.png")
@@ -43,7 +43,7 @@ class Main(object):
         # Toppers
         #
         parameters = {"action": "list", "plugin_category": LANGUAGE(30000),
-                      "url": "http://www.dumpert.nl/toppers/1/", "next_page_possible": "True"}
+                      "url": "http://legacy.dumpert.nl/toppers/1/", "next_page_possible": "True"}
         url = self.plugin_url + '?' + urllib.parse.urlencode(parameters)
         list_item = xbmcgui.ListItem(LANGUAGE(30000), iconImage="DefaultFolder.png")
         is_folder = True
@@ -69,7 +69,7 @@ class Main(object):
         # Floppers
         #
         parameters = {"action": "list", "plugin_category": LANGUAGE(30003),
-                      "url": "http://www.dumpert.nl/floppers/1/", "next_page_possible": "True"}
+                      "url": "http://legacy.dumpert.nl/floppers/1/", "next_page_possible": "True"}
         url = self.plugin_url + '?' + urllib.parse.urlencode(parameters)
         list_item = xbmcgui.ListItem(LANGUAGE(30003), iconImage="DefaultFolder.png")
         is_folder = True
@@ -93,7 +93,7 @@ class Main(object):
         # Themas
         #
         parameters = {"action": "list-themas", "plugin_category": LANGUAGE(30002),
-                      "url": "http://www.dumpert.nl/themas/1/", "next_page_possible": "False"}
+                      "url": "http://legacy.dumpert.nl/themas/1/", "next_page_possible": "False"}
         url = self.plugin_url + '?' + urllib.parse.urlencode(parameters)
         list_item = xbmcgui.ListItem(LANGUAGE(30002), iconImage="DefaultFolder.png")
         is_folder = True
@@ -105,7 +105,7 @@ class Main(object):
         # Search
         #
         parameters = {"action": "search", "plugin_category": LANGUAGE(30004),
-                      "url": "http://www.dumpert.nl/search/", "next_page_possible": "True"}
+                      "url": "http://legacy.dumpert.nl/search/", "next_page_possible": "True"}
         url = self.plugin_url + '?' + urllib.parse.urlencode(parameters)
         list_item = xbmcgui.ListItem(LANGUAGE(30004), iconImage="DefaultFolder.png")
         is_folder = True

--- a/resources/lib/dumpert_play.py
+++ b/resources/lib/dumpert_play.py
@@ -45,7 +45,7 @@ class Main(object):
         # Try and get the title.
         # When starting a video with a browser (f.e. in chrome the 'send to kodi'-extension) the url will be
         # something like this:
-        # plugin://plugin.video.dumpert/?action=play&video_page_url=http%3A%2F%2Fwww.dumpert.nl%2Fmediabase%2F7095997%2F1f72985c%2Fmevrouw_heeft_internetje_thuis.html
+        # plugin://plugin.video.dumpert/?action=play&video_page_url=http%3A%2F%2Flegacy.dumpert.nl%2Fmediabase%2F7095997%2F1f72985c%2Fmevrouw_heeft_internetje_thuis.html
         # and there won't be a title available.
         try:
             self.title = urllib.parse.parse_qs(urllib.parse.urlparse(sys.argv[2]).query)['title'][0]

--- a/resources/lib/dumpert_search.py
+++ b/resources/lib/dumpert_search.py
@@ -38,7 +38,7 @@ class Main(object):
             search_term = keyboard.getText()
 
         sys.argv[2] = convertToUnicodeString(sys.argv[2])
-        # Converting URL argument to proper query string like 'http://www.dumpert.nl/search/ALL/fiets/1/'
+        # Converting URL argument to proper query string like 'http://legacy.dumpert.nl/search/ALL/fiets/1/'
         sys.argv[2] = sys.argv[2] + "/ALL/" + search_term + "/1/'"
 
         log("sys.argv[2]", sys.argv[2])


### PR DESCRIPTION
New design went live yesterday. This just replaces the logo to the updated version and all www.dumpert.nl to legacy.dumpert.nl as a quickfix.