### PR TITLE
Fix DumpertTV section returning no videos

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -2,7 +2,7 @@
 <addon
 	id="plugin.video.dumpert"
 	name="Dumpert"
-	version="1.1.10"
+  version="1.1.11"
 	provider-name="Skipmode A1">
   <requires>
     <import addon="xbmc.python"                     version="2.20.0"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+v1.1.11 (2026-06-24)
+- Fixed DumpertTV feed URL to use api-live.dumpert.nl directly
+
 v1.1.10 (2019-12-12) (thanks for the help Nixxor)
 - Removed Top as it is basically the same as Daily Top
 - Using different url for DumpertTV so that most recent items are at the top of the list

--- a/resources/lib/dumpert_const.py
+++ b/resources/lib/dumpert_const.py
@@ -16,7 +16,7 @@ LANGUAGE = SETTINGS.getLocalizedString
 IMAGES_PATH = os.path.join(xbmcaddon.Addon(id=ADDON).getAddonInfo('path'), 'resources', 'images')
 LATEST_URL = "https://api-live.dumpert.nl/mobile_api/json/video/latest/0/"
 TOPPERS_URL = "https://api-live.dumpert.nl/mobile_api/json/video/toppers/0/"
-DUMPERT_TV_URL = "https://api.dumpert.nl/mobile_api/json/dumperttv/0/"
+DUMPERT_TV_URL = "https://api-live.dumpert.nl/mobile_api/json/dumperttv/0/"
 SEARCH_URL = "https://api-live.dumpert.nl/mobile_api/json/search/"
 DAY_TOPPERS_URL = "https://api-live.dumpert.nl/mobile_api/json/video/top5/dag/"
 WEEK_TOPPERS_URL = "https://api-live.dumpert.nl/mobile_api/json/video/top5/week/"
@@ -29,8 +29,8 @@ MONTH = "month"
 VIDEO_QUALITY_MOBILE = "mobile"
 VIDEO_QUALITY_TABLET = "tablet"
 VIDEO_QUALITY_720P = "720p"
-DATE = "2019-12-14"
-VERSION = "1.1.10"
+DATE = "2026-06-24"
+VERSION = "1.1.11"
 
 
 if sys.version_info[0] > 2:


### PR DESCRIPTION
This PR fixes the DumpertTV section by updating its feed host to api-live.\n\nRoot cause\n- DumpertTV used https://api.dumpert.nl/mobile_api/json/dumperttv/0/ while the rest of the addon already uses api-live.dumpert.nl.\n- In older Kodi/request stacks, redirect/TLS handling on the api host can fail for this section, resulting in no items shown.\n\nChanges\n- Update DUMPERT_TV_URL to https://api-live.dumpert.nl/mobile_api/json/dumperttv/0/\n- Bump addon version to 1.1.11\n- Add changelog entry\n\nVerification\n- Endpoint returns success=true with items from api-live dumperttv feed.